### PR TITLE
attribute model specifiable by propertymapper

### DIFF
--- a/app/code/Magento/Eav/Model/Entity/Setup/PropertyMapper.php
+++ b/app/code/Magento/Eav/Model/Entity/Setup/PropertyMapper.php
@@ -22,6 +22,7 @@ class PropertyMapper extends PropertyMapperAbstract
     public function map(array $input, $entityTypeId)
     {
         return [
+            'attribute_model' => $this->_getValue($input, 'attribute_model'),
             'backend_model' => $this->_getValue($input, 'backend'),
             'backend_type' => $this->_getValue($input, 'type', 'varchar'),
             'backend_table' => $this->_getValue($input, 'table'),


### PR DESCRIPTION
This way you can specify an attribute model using data upgrade script.
Multi select attribute only work if there is a backend model specified.
